### PR TITLE
React shouldn't be a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "author": "Chris Kjær Sørensen",
   "license": "MIT",
   "dependencies": {
-    "react": ">=0.11.0",
     "babel-runtime": "^5.5.8"
   },
   "devDependencies": {
@@ -35,7 +34,8 @@
     "css": "^2.2.0",
     "mocha": "^2.2.4",
     "mocha-clean": "^0.4.0",
-    "semver": "^4.3.6"
+    "semver": "^4.3.6",
+    "react": ">=0.11.0"
   },
   "repository": "chriskjaer/stilr"
 }


### PR DESCRIPTION
React isn't needed for this module to work + including React as a dependency means under some conditions it'll get required twice which leads to weird bugs.
