### PR TITLE
Don't suggest using deprecated autoprefixer-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ If you're using [React Hot Loader](https://github.com/gaearon/react-hot-loader).
 ```javascript
 import React from 'react';
 import StyleSheet from 'stilr';
-import autoprefixer from 'autoprefixer-core';
+import autoprefixer from 'autoprefixer';
 import postcss from 'postcss';
 
 


### PR DESCRIPTION
`autoprefixer-core` has been deprecated and we can just import the regular package instead :)