### PR TITLE
Support for Maps in isEmpty function. (refactoring)

### DIFF
--- a/lib/__tests__/utils.test.js
+++ b/lib/__tests__/utils.test.js
@@ -4,12 +4,17 @@ import * as utils from '../utils';
 describe('utils', () => {
 
   describe('#isEmpty', () => {
-    it('{} is empty', () => {
+    it('`{}` is empty', () => {
       assert(utils.isEmpty({}));
     });
 
-    it('{notEmpty: 1} isn\'t empty', () => {
+    it('`{notEmpty: 1}` isn\'t empty', () => {
       assert(!utils.isEmpty({notEmpty: 1}));
+    });
+
+    it('`new Map()` is empty', () => {
+      const emptyMap = new Map();
+      assert(utils.isEmpty(emptyMap));
     });
   });
 

--- a/lib/__tests__/utils.test.js
+++ b/lib/__tests__/utils.test.js
@@ -7,6 +7,10 @@ describe('utils', () => {
     it('{} is empty', () => {
       assert(utils.isEmpty({}));
     });
+
+    it('{notEmpty: 1} isn\'t empty', () => {
+      assert(!utils.isEmpty({notEmpty: 1}));
+    });
   });
 
 

--- a/lib/__tests__/utils.test.js
+++ b/lib/__tests__/utils.test.js
@@ -3,6 +3,14 @@ import * as utils from '../utils';
 
 describe('utils', () => {
 
+  describe('#isEmpty', () => {
+    it('{} is empty', () => {
+      assert(utils.isEmpty({}));
+    });
+  });
+
+
+
   describe('#sortObject(obj)', () => {
     it('removes falsy', () => {
       const fixture = {

--- a/lib/__tests__/utils.test.js
+++ b/lib/__tests__/utils.test.js
@@ -24,8 +24,6 @@ describe('utils', () => {
     });
   });
 
-
-
   describe('#sortObject(obj)', () => {
     it('removes falsy', () => {
       const fixture = {

--- a/lib/__tests__/utils.test.js
+++ b/lib/__tests__/utils.test.js
@@ -4,15 +4,15 @@ import * as utils from '../utils';
 describe('utils', () => {
 
   describe('#isEmpty', () => {
-    it('`{}` is empty', () => {
+    it('object without a property set is empty', () => {
       assert(utils.isEmpty({}));
     });
 
-    it('`{notEmpty: 1}` isn\'t empty', () => {
+    it('object with a property set isn\'t empty', () => {
       assert(!utils.isEmpty({notEmpty: 1}));
     });
 
-    it('`new Map()` is empty', () => {
+    it('`Map` without a property set is empty', () => {
       const emptyMap = new Map();
       assert(utils.isEmpty(emptyMap));
     });

--- a/lib/__tests__/utils.test.js
+++ b/lib/__tests__/utils.test.js
@@ -16,6 +16,12 @@ describe('utils', () => {
       const emptyMap = new Map();
       assert(utils.isEmpty(emptyMap));
     });
+
+    it('`Map` with property set isn\'t empty', () => {
+      const map = new Map();
+      map.set('notEmpty', true);
+      assert(!utils.isEmpty(map));
+    });
   });
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,9 +8,12 @@ import {
 
 const globalStylesheet = new Map();
 
+const isInstanceOfMap = (object) =>
+  object instanceof Map;
+
 export default {
   create( styles, stylesheet = globalStylesheet ) {
-    if ( !(stylesheet instanceof Map) ) throw new Error(`${ stylesheet } should be a Map`);
+    if ( !(isInstanceOfMap(stylesheet)) ) throw new Error(`${ stylesheet } should be a Map`);
 
     return Object.keys( styles ).reduce( ( acc, key ) => {
 
@@ -88,7 +91,7 @@ export default {
     for ( const entry of stylesheetEntries ) {
       const className = entry[0];
       const styles = entry[1];
-      const isMap = styles instanceof Map;
+      const isMap = isInstanceOfMap(styles);
 
       if (!isMap && isEmpty(styles)) continue;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,12 +4,11 @@ import {
   createMarkup,
   seperateStyles,
   isEmpty,
+  isInstanceOfMap,
 } from './utils';
 
 const globalStylesheet = new Map();
 
-const isInstanceOfMap = (object) =>
-  object instanceof Map;
 
 export default {
   create( styles, stylesheet = globalStylesheet ) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -92,7 +92,7 @@ export default {
       const styles = entry[1];
       const isMap = isInstanceOfMap(styles);
 
-      if (!isMap && isEmpty(styles)) continue;
+      if (isEmpty(styles)) continue;
 
       if (isMap) {
         const mediaQueryCSS = this.render(options, stylesheet.get( className ) );

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -58,11 +58,17 @@ export function createMarkup(obj) {
   return createMarkupForStyles( obj );
 }
 
-export function isEmpty(obj) {
-  if(isInstanceOfMap(obj)) {
-    return obj.size === 0;
-  }
+function isMapEmpty(obj) {
+  return obj.size === 0;
+}
+
+function isObjectEmpty(obj) {
   return !Object.keys(obj).length;
+}
+
+export function isEmpty(obj) {
+  if(isInstanceOfMap(obj)) { return isMapEmpty(obj); }
+  return isObjectEmpty(obj);
 }
 
 export function isPseudo({ style, rule }) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -70,6 +70,10 @@ export function isMediaQuery({ style, rule }) {
   return rule.charAt(0) === '@' && typeof style === 'object';
 }
 
+export function isInstanceOfMap(object) {
+  return object instanceof Map;
+}
+
 function handle(type, acc, { style, rule }, pseudos = []) {
   const hash = createClassName( sortObject( style ));
   const rules = pseudos.length

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -59,6 +59,9 @@ export function createMarkup(obj) {
 }
 
 export function isEmpty(obj) {
+  if(isInstanceOfMap(obj)) {
+    return obj.size === 0;
+  }
   return !Object.keys(obj).length;
 }
 


### PR DESCRIPTION
[Line 93](https://github.com/kodyl/stilr/compare/master...webPapaya:is-empty?expand=1#diff-6d186b954a58d5bb740f73d84fe39073L93) should check if the styles are empty or not. Until now the `isEmpty` function only supports objects and no `Maps`. So this PR adds a Map support to the isEmpty function and replaces:

```js
if (!isMap && isEmpty(styles)) continue;
```
with 
```js
if (isEmpty(styles)) continue;
```