### PR TITLE
Remove `babel-eslint`and `eslint-plugin-react` as a dependency

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,12 @@
 {
-  "parser": "babel-eslint",
   "env": {
     "es6": true,
     "browser": true,
     "node": true,
     "mocha": true
+  },
+  "parserOptions": {
+    "sourceType": "module"
   },
   "extends": "eslint:recommended",
   "rules": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -6,9 +6,6 @@
     "node": true,
     "mocha": true
   },
-  "plugins": [
-    "react"
-  ],
   "extends": "eslint:recommended",
   "rules": {
     "quotes": [2, "single"],

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "babel": "^6.5.2",
     "babel-cli": "^6.7.5",
     "babel-core": "^6.7.6",
-    "babel-eslint": "^6.0.2",
     "babel-loader": "^6.2.4",
     "babel-plugin-add-module-exports": "^0.1.2",
     "babel-polyfill": "^6.7.4",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "babel-register": "^6.7.2",
     "css": "^2.2.0",
     "eslint": "^2.7.0",
-    "eslint-plugin-react": "^4.0.0",
     "mocha": "^2.2.4",
     "mocha-clean": "^1.0.0",
     "semver": "^5.1.0"


### PR DESCRIPTION
This PR removes two dependencies from the stilr:
* babel-eslint
* eslint-plugin-react

## Why remove babel-eslint
> ESLint allows custom parsers. This is great but some of the syntax nodes that Babel supports aren't supported by ESLint. When using this plugin, ESLint is monkeypatched and your code is transformed into code that ESLint can understand. All location info such as line numbers, columns is also retained so you can track down errors with ease. (https://github.com/babel/babel-eslint#how-does-it-work)

I think since version 2 of eslint they have a good support for the new es6 syntax. As stilr is currently not using any syntax which isn't supported by the eslint default parser, we should remove `babel-eslint` for now. We can think about reenable it if somebody want's to use a new and fancy js syntax which is currently not supported by eslint.

## Why remove eslint-plugin-react
While reading through the list of supported rules of `eslint-plugin-react` I realized that all of the rules are very react/jsx centric. As stilr is not using any jsx or react we can safely remove `eslint-plugin-react`. 