### PR TITLE
Add type declaration file for typescript

### DIFF
--- a/stilr.d.ts
+++ b/stilr.d.ts
@@ -1,0 +1,11 @@
+declare module 'stilr' {
+  namespace Stilr {
+    type StyleSheet = Map<string, any>;
+
+    function create(styles: any, stylesheet?: StyleSheet): any;
+    function render(options?: Object, stylesheet?: StyleSheet): string;
+    function clear(stylesheet: StyleSheet): Boolean;
+  }
+
+  export = Stilr;
+}


### PR DESCRIPTION
I have added a type declaration file for using Stilr in a typescript environment.

It's probably missing a few things and we can probably have more specific types but at least i have tested it with `StyleSheet.create` and `StyleSheet.render` and it is working.
