### PR TITLE
Remove React as a dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - '7.1'
-  - '6.9'
-  - '5.11'
-  - '4.6'
-script: make lint && make dist && make test-dist
+  - 'node'
+  - '6'
+  - '5'
+  - '4'
+script: make build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 node_js:
-  - '5.6'
-  - '5.0'
-  - '4.3'
-  - '4.2'
-  - '4.0'
+  - '7.1'
+  - '6.9'
+  - '5.11'
+  - '4.6'
+  - '0.12'
+  - '0.10'
 script: make lint && make dist && make test-dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,4 @@ node_js:
   - '6.9'
   - '5.11'
   - '4.6'
-  - '0.12'
-  - '0.10'
 script: make lint && make dist && make test-dist

--- a/dist/index.js
+++ b/dist/index.js
@@ -24,16 +24,15 @@ var globalStylesheet = new _map2.default();
 
 exports.default = {
   create: function create(styles) {
-    var stylesheet = arguments.length <= 1 || arguments[1] === undefined ? globalStylesheet : arguments[1];
+    var stylesheet = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : globalStylesheet;
 
     if (!(stylesheet instanceof _map2.default)) throw new Error(stylesheet + ' should be a Map');
 
     return (0, _keys2.default)(styles).reduce(function (acc, key) {
-      var _seperateStyles = (0, _utils.seperateStyles)(styles[key]);
-
-      var style = _seperateStyles.style;
-      var pseudos = _seperateStyles.pseudos;
-      var mediaQueries = _seperateStyles.mediaQueries;
+      var _seperateStyles = (0, _utils.seperateStyles)(styles[key]),
+          style = _seperateStyles.style,
+          pseudos = _seperateStyles.pseudos,
+          mediaQueries = _seperateStyles.mediaQueries;
 
       var className = (0, _utils.createClassName)((0, _utils.sortObject)(style));
 
@@ -97,8 +96,8 @@ exports.default = {
     }, {});
   },
   render: function render() {
-    var options = arguments.length <= 0 || arguments[0] === undefined ? { pretty: false } : arguments[0];
-    var stylesheet = arguments.length <= 1 || arguments[1] === undefined ? globalStylesheet : arguments[1];
+    var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : { pretty: false };
+    var stylesheet = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : globalStylesheet;
 
     var stylesheetEntries = stylesheet.entries();
     var css = '';
@@ -145,7 +144,7 @@ exports.default = {
     return css + mediaQueries;
   },
   clear: function clear() {
-    var stylesheet = arguments.length <= 0 || arguments[0] === undefined ? globalStylesheet : arguments[0];
+    var stylesheet = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : globalStylesheet;
 
     stylesheet.clear();
     return !stylesheet.size;

--- a/dist/utils/CSSProperty.js
+++ b/dist/utils/CSSProperty.js
@@ -1,0 +1,152 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.shorthandPropertyExpansions = exports.isUnitlessNumber = undefined;
+
+var _keys = require('babel-runtime/core-js/object/keys');
+
+var _keys2 = _interopRequireDefault(_keys);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule CSSProperty
+ */
+
+/**
+ * CSS properties which accept numbers but are not in units of "px".
+ */
+
+var isUnitlessNumber = exports.isUnitlessNumber = {
+  animationIterationCount: true,
+  borderImageOutset: true,
+  borderImageSlice: true,
+  borderImageWidth: true,
+  boxFlex: true,
+  boxFlexGroup: true,
+  boxOrdinalGroup: true,
+  columnCount: true,
+  flex: true,
+  flexGrow: true,
+  flexPositive: true,
+  flexShrink: true,
+  flexNegative: true,
+  flexOrder: true,
+  gridRow: true,
+  gridColumn: true,
+  fontWeight: true,
+  lineClamp: true,
+  lineHeight: true,
+  opacity: true,
+  order: true,
+  orphans: true,
+  tabSize: true,
+  widows: true,
+  zIndex: true,
+  zoom: true,
+
+  // SVG-related properties
+  fillOpacity: true,
+  floodOpacity: true,
+  stopOpacity: true,
+  strokeDasharray: true,
+  strokeDashoffset: true,
+  strokeMiterlimit: true,
+  strokeOpacity: true,
+  strokeWidth: true
+};
+
+/**
+ * @param {string} prefix vendor-specific prefix, eg: Webkit
+ * @param {string} key style name, eg: transitionDuration
+ * @return {string} style name prefixed with `prefix`, properly camelCased, eg:
+ * WebkitTransitionDuration
+ */
+function prefixKey(prefix, key) {
+  return prefix + key.charAt(0).toUpperCase() + key.substring(1);
+}
+
+/**
+ * Support style names that may come passed in prefixed by adding permutations
+ * of vendor prefixes.
+ */
+var prefixes = ['Webkit', 'ms', 'Moz', 'O'];
+
+// Using Object.keys here, or else the vanilla for-in loop makes IE8 go into an
+// infinite loop, because it iterates over the newly added props too.
+(0, _keys2.default)(isUnitlessNumber).forEach(function (prop) {
+  prefixes.forEach(function (prefix) {
+    isUnitlessNumber[prefixKey(prefix, prop)] = isUnitlessNumber[prop];
+  });
+});
+
+/**
+ * Most style properties can be unset by doing .style[prop] = '' but IE8
+ * doesn't like doing that with shorthand properties so for the properties that
+ * IE8 breaks on, which are listed here, we instead unset each of the
+ * individual properties. See http://bugs.jquery.com/ticket/12385.
+ * The 4-value 'clock' properties like margin, padding, border-width seem to
+ * behave without any problems. Curiously, list-style works too without any
+ * special prodding.
+ */
+var shorthandPropertyExpansions = exports.shorthandPropertyExpansions = {
+  background: {
+    backgroundAttachment: true,
+    backgroundColor: true,
+    backgroundImage: true,
+    backgroundPositionX: true,
+    backgroundPositionY: true,
+    backgroundRepeat: true
+  },
+  backgroundPosition: {
+    backgroundPositionX: true,
+    backgroundPositionY: true
+  },
+  border: {
+    borderWidth: true,
+    borderStyle: true,
+    borderColor: true
+  },
+  borderBottom: {
+    borderBottomWidth: true,
+    borderBottomStyle: true,
+    borderBottomColor: true
+  },
+  borderLeft: {
+    borderLeftWidth: true,
+    borderLeftStyle: true,
+    borderLeftColor: true
+  },
+  borderRight: {
+    borderRightWidth: true,
+    borderRightStyle: true,
+    borderRightColor: true
+  },
+  borderTop: {
+    borderTopWidth: true,
+    borderTopStyle: true,
+    borderTopColor: true
+  },
+  font: {
+    fontStyle: true,
+    fontVariant: true,
+    fontWeight: true,
+    fontSize: true,
+    lineHeight: true,
+    fontFamily: true
+  },
+  outline: {
+    outlineWidth: true,
+    outlineStyle: true,
+    outlineColor: true
+  }
+};

--- a/dist/utils/CSSPropertyOperations.js
+++ b/dist/utils/CSSPropertyOperations.js
@@ -1,0 +1,206 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.createMarkupForStyles = createMarkupForStyles;
+exports.setValueForStyles = setValueForStyles;
+
+var _CSSProperty = require('./CSSProperty');
+
+var _dangerousStyleValue = require('./dangerousStyleValue');
+
+var _dangerousStyleValue2 = _interopRequireDefault(_dangerousStyleValue);
+
+var _fbjs = require('./fbjs');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+// var ExecutionEnvironment = require('fbjs/lib/ExecutionEnvironment');
+// var camelizeStyleName = require('fbjs/lib/camelizeStyleName');
+// var hyphenateStyleName = require('fbjs/lib/hyphenateStyleName');
+// var memoizeStringOnly = require('fbjs/lib/memoizeStringOnly');
+// var warning = require('fbjs/lib/warning');
+
+var processStyleName = (0, _fbjs.memoizeStringOnly)(function (styleName) {
+  return (0, _fbjs.hyphenateStyleName)(styleName);
+}); /**
+     * Copyright 2013-present, Facebook, Inc.
+     * All rights reserved.
+     *
+     * This source code is licensed under the BSD-style license found in the
+     * LICENSE file in the root directory of this source tree. An additional grant
+     * of patent rights can be found in the PATENTS file in the same directory.
+     *
+     * @providesModule CSSPropertyOperations
+     */
+
+var hasShorthandPropertyBug = false;
+var styleFloatAccessor = 'cssFloat';
+if (_fbjs.ExecutionEnvironment.canUseDOM) {
+  var tempStyle = document.createElement('div').style;
+  try {
+    // IE8 throws "Invalid argument." if resetting shorthand style properties.
+    tempStyle.font = '';
+  } catch (e) {
+    hasShorthandPropertyBug = true;
+  }
+  // IE8 only supports accessing cssFloat (standard) as styleFloat
+  if (document.documentElement.style.cssFloat === undefined) {
+    styleFloatAccessor = 'styleFloat';
+  }
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  // 'msTransform' is correct, but the other prefixes should be capitalized
+  var badVendoredStyleNamePattern = /^(?:webkit|moz|o)[A-Z]/;
+
+  // style values shouldn't contain a semicolon
+  var badStyleValueWithSemicolonPattern = /;\s*$/;
+
+  var warnedStyleNames = {};
+  var warnedStyleValues = {};
+  var warnedForNaNValue = false;
+
+  var warnHyphenatedStyleName = function warnHyphenatedStyleName(name, owner) {
+    if (warnedStyleNames.hasOwnProperty(name) && warnedStyleNames[name]) {
+      return;
+    }
+
+    warnedStyleNames[name] = true;
+    (0, _fbjs.warning)(false, 'Unsupported style property %s. Did you mean %s?%s', name, (0, _fbjs.camelizeStyleName)(name), checkRenderMessage(owner));
+  };
+
+  var warnBadVendoredStyleName = function warnBadVendoredStyleName(name, owner) {
+    if (warnedStyleNames.hasOwnProperty(name) && warnedStyleNames[name]) {
+      return;
+    }
+
+    warnedStyleNames[name] = true;
+    (0, _fbjs.warning)(false, 'Unsupported vendor-prefixed style property %s. Did you mean %s?%s', name, name.charAt(0).toUpperCase() + name.slice(1), checkRenderMessage(owner));
+  };
+
+  var warnStyleValueWithSemicolon = function warnStyleValueWithSemicolon(name, value, owner) {
+    if (warnedStyleValues.hasOwnProperty(value) && warnedStyleValues[value]) {
+      return;
+    }
+
+    warnedStyleValues[value] = true;
+    (0, _fbjs.warning)(false, 'Style property values shouldn\'t contain a semicolon.%s ' + 'Try "%s: %s" instead.', checkRenderMessage(owner), name, value.replace(badStyleValueWithSemicolonPattern, ''));
+  };
+
+  var warnStyleValueIsNaN = function warnStyleValueIsNaN(name, value, owner) {
+    if (warnedForNaNValue) {
+      return;
+    }
+
+    warnedForNaNValue = true;
+    (0, _fbjs.warning)(false, '`NaN` is an invalid value for the `%s` css style property.%s', name, checkRenderMessage(owner));
+  };
+
+  var checkRenderMessage = function checkRenderMessage(owner) {
+    if (owner) {
+      var name = owner.getName();
+      if (name) {
+        return ' Check the render method of `' + name + '`.';
+      }
+    }
+    return '';
+  };
+
+  /**
+   * @param {string} name
+   * @param {*} value
+   * @param {ReactDOMComponent} component
+   */
+  var warnValidStyle = function warnValidStyle(name, value, component) {
+    var owner;
+    if (component) {
+      owner = component._currentElement._owner;
+    }
+    if (name.indexOf('-') > -1) {
+      warnHyphenatedStyleName(name, owner);
+    } else if (badVendoredStyleNamePattern.test(name)) {
+      warnBadVendoredStyleName(name, owner);
+    } else if (badStyleValueWithSemicolonPattern.test(value)) {
+      warnStyleValueWithSemicolon(name, value, owner);
+    }
+
+    if (typeof value === 'number' && isNaN(value)) {
+      warnStyleValueIsNaN(name, value, owner);
+    }
+  };
+}
+
+/**
+ * Operations for dealing with CSS properties.
+ */
+
+/**
+ * Serializes a mapping of style properties for use as inline styles:
+ *
+ *   > createMarkupForStyles({width: '200px', height: 0})
+ *   "width:200px;height:0;"
+ *
+ * Undefined values are ignored so that declarative programming is easier.
+ * The result should be HTML-escaped before insertion into the DOM.
+ *
+ * @param {object} styles
+ * @param {ReactDOMComponent} component
+ * @return {?string}
+ */
+function createMarkupForStyles(styles, component) {
+  var serialized = '';
+  for (var styleName in styles) {
+    if (!styles.hasOwnProperty(styleName)) {
+      continue;
+    }
+    var styleValue = styles[styleName];
+    if (process.env.NODE_ENV !== 'production') {
+      warnValidStyle(styleName, styleValue, component);
+    }
+    if (styleValue != null) {
+      serialized += processStyleName(styleName) + ':';
+      serialized += (0, _dangerousStyleValue2.default)(styleName, styleValue, component) + ';';
+    }
+  }
+  return serialized || null;
+}
+
+/**
+ * Sets the value for multiple styles on a node.  If a value is specified as
+ * '' (empty string), the corresponding style property will be unset.
+ *
+ * @param {DOMElement} node
+ * @param {object} styles
+ * @param {ReactDOMComponent} component
+ */
+function setValueForStyles(node, styles, component) {
+  var style = node.style;
+  for (var styleName in styles) {
+    if (!styles.hasOwnProperty(styleName)) {
+      continue;
+    }
+    if (process.env.NODE_ENV !== 'production') {
+      warnValidStyle(styleName, styles[styleName], component);
+    }
+    var styleValue = (0, _dangerousStyleValue2.default)(styleName, styles[styleName], component);
+    if (styleName === 'float' || styleName === 'cssFloat') {
+      styleName = styleFloatAccessor;
+    }
+    if (styleValue) {
+      style[styleName] = styleValue;
+    } else {
+      var expansion = hasShorthandPropertyBug && _CSSProperty.shorthandPropertyExpansions[styleName];
+      if (expansion) {
+        // Shorthand property that IE8 won't like unsetting, so unset each
+        // component to placate it
+        for (var individualStyleName in expansion) {
+          style[individualStyleName] = '';
+        }
+      } else {
+        style[styleName] = '';
+      }
+    }
+  }
+}

--- a/dist/utils/dangerousStyleValue.js
+++ b/dist/utils/dangerousStyleValue.js
@@ -1,0 +1,81 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = dangerousStyleValue;
+
+var _CSSProperty = require('./CSSProperty');
+
+var _fbjs = require('./fbjs');
+
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule dangerousStyleValue
+ */
+
+var styleWarnings = {};
+
+/**
+ * Convert a value into the proper css writable value. The style name `name`
+ * should be logical (no hyphens), as specified
+ * in `CSSProperty.isUnitlessNumber`.
+ *
+ * @param {string} name CSS property name such as `topMargin`.
+ * @param {*} value CSS property value such as `10px`.
+ * @param {ReactDOMComponent} component
+ * @return {string} Normalized style value with dimensions applied.
+ */
+function dangerousStyleValue(name, value, component) {
+  // Note that we've removed escapeTextForBrowser() calls here since the
+  // whole string will be escaped when the attribute is injected into
+  // the markup. If you provide unsafe user data here they can inject
+  // arbitrary CSS which may be problematic (I couldn't repro this):
+  // https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet
+  // http://www.thespanner.co.uk/2007/11/26/ultimate-xss-css-injection/
+  // This is not an XSS hole but instead a potential CSS injection issue
+  // which has lead to a greater discussion about how we're going to
+  // trust URLs moving forward. See #2115901
+
+  var isEmpty = value == null || typeof value === 'boolean' || value === '';
+  if (isEmpty) {
+    return '';
+  }
+
+  var isNonNumeric = isNaN(value);
+  if (isNonNumeric || value === 0 || _CSSProperty.isUnitlessNumber.hasOwnProperty(name) && _CSSProperty.isUnitlessNumber[name]) {
+    return '' + value; // cast to string
+  }
+
+  if (typeof value === 'string') {
+    if (process.env.NODE_ENV !== 'production') {
+      if (component) {
+        var owner = component._currentElement._owner;
+        var ownerName = owner ? owner.getName() : null;
+        if (ownerName && !styleWarnings[ownerName]) {
+          styleWarnings[ownerName] = {};
+        }
+        var warned = false;
+        if (ownerName) {
+          var warnings = styleWarnings[ownerName];
+          warned = warnings[name];
+          if (!warned) {
+            warnings[name] = true;
+          }
+        }
+        if (!warned) {
+          (0, _fbjs.warning)(false, 'a `%s` tag (owner: `%s`) was passed a numeric string value ' + 'for CSS property `%s` (value: `%s`) which will be treated ' + 'as a unitless number in a future version of React.', component._currentElement.type, ownerName || 'unknown', name, value);
+        }
+      }
+    }
+    value = value.trim();
+  }
+  return value + 'px';
+}
+module.exports = exports['default'];

--- a/dist/utils/fbjs.js
+++ b/dist/utils/fbjs.js
@@ -1,0 +1,187 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.hyphenateStyleName = hyphenateStyleName;
+exports.camelizeStyleName = camelizeStyleName;
+exports.memoizeStringOnly = memoizeStringOnly;
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+// ExecutionEnvironment.js
+
+var canUseDOM = !!(typeof window !== 'undefined' && window.document && window.document.createElement);
+
+/**
+ * Simple, lightweight module assisting with the detection and context of
+ * Worker. Helps avoid circular dependencies and allows code to reason about
+ * whether or not they are in a Worker, even if they never include the main
+ * `ReactWorker` dependency.
+ */
+var ExecutionEnvironment = exports.ExecutionEnvironment = {
+
+  canUseDOM: canUseDOM,
+
+  canUseWorkers: typeof Worker !== 'undefined',
+
+  canUseEventListeners: canUseDOM && !!(window.addEventListener || window.attachEvent),
+
+  canUseViewport: canUseDOM && !!window.screen,
+
+  isInWorker: !canUseDOM // For now, this is true - might change in the future.
+
+};
+
+// ---------------------
+
+// hypenate.js
+
+var _uppercasePattern = /([A-Z])/g;
+
+/**
+ * Hyphenates a camelcased string, for example:
+ *
+ *   > hyphenate('backgroundColor')
+ *   < "background-color"
+ *
+ * For CSS style names, use `hyphenateStyleName` instead which works properly
+ * with all vendor prefixes, including `ms`.
+ *
+ * @param {string} string
+ * @return {string}
+ */
+function hyphenate(string) {
+  return string.replace(_uppercasePattern, '-$1').toLowerCase();
+}
+
+// ---------------------
+
+// hyphenateStyleName.js
+
+var msPattern = /^ms-/;
+
+/**
+ * Hyphenates a camelcased CSS property name, for example:
+ *
+ *   > hyphenateStyleName('backgroundColor')
+ *   < "background-color"
+ *   > hyphenateStyleName('MozTransition')
+ *   < "-moz-transition"
+ *   > hyphenateStyleName('msTransition')
+ *   < "-ms-transition"
+ *
+ * As Modernizr suggests (http://modernizr.com/docs/#prefixed), an `ms` prefix
+ * is converted to `-ms-`.
+ *
+ * @param {string} string
+ * @return {string}
+ */
+function hyphenateStyleName(string) {
+  return hyphenate(string).replace(msPattern, '-ms-');
+}
+
+// ---------------------
+
+// camelize.js
+
+var _hyphenPattern = /-(.)/g;
+
+/**
+ * Camelcases a hyphenated string, for example:
+ *
+ *   > camelize('background-color')
+ *   < "backgroundColor"
+ *
+ * @param {string} string
+ * @return {string}
+ */
+function camelize(string) {
+  return string.replace(_hyphenPattern, function (_, character) {
+    return character.toUpperCase();
+  });
+}
+
+// ---------------------
+
+// camelizeStyleName.js
+
+var dashMsPattern = /^-ms-/; // renamed from msPattern to avoid name conflict
+
+/**
+ * Camelcases a hyphenated CSS property name, for example:
+ *
+ *   > camelizeStyleName('background-color')
+ *   < "backgroundColor"
+ *   > camelizeStyleName('-moz-transition')
+ *   < "MozTransition"
+ *   > camelizeStyleName('-ms-transition')
+ *   < "msTransition"
+ *
+ * As Andi Smith suggests
+ * (http://www.andismith.com/blog/2012/02/modernizr-prefixed/), an `-ms` prefix
+ * is converted to lowercase `ms`.
+ *
+ * @param {string} string
+ * @return {string}
+ */
+function camelizeStyleName(string) {
+  return camelize(string.replace(dashMsPattern, 'ms-'));
+}
+
+// ---------------------
+
+// memoizeStringOnly.js
+
+/**
+ * Memoizes the return value of a function that accepts one string argument.
+ */
+function memoizeStringOnly(callback) {
+  var cache = {};
+  return function (string) {
+    if (!cache.hasOwnProperty(string)) {
+      cache[string] = callback.call(this, string);
+    }
+    return cache[string];
+  };
+}
+
+// ---------------------
+
+// warning.js
+
+var warning = exports.warning = function warning() {};
+
+// if (__DEV__) {
+//   function printWarning(format, ...args) {
+//     var argIndex = 0;
+//     var message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
+//     if (typeof console !== 'undefined') {
+//       console.error(message);
+//     }
+//     try {
+//       // --- Welcome to debugging React ---
+//       // This error was thrown as a convenience so that you can use this stack
+//       // to find the callsite that caused this warning to fire.
+//       throw new Error(message);
+//     } catch (x) {}
+//   }
+//
+//   warning = function(condition, format, ...args) {
+//     if (format === undefined) {
+//       throw new Error(
+//         '`warning(condition, format, ...args)` requires a warning ' +
+//         'message argument'
+//       );
+//     }
+//     if (!condition) {
+//       printWarning(format, ...args);
+//     }
+//   };
+// }

--- a/dist/utils/index.js
+++ b/dist/utils/index.js
@@ -27,7 +27,7 @@ exports.isPseudo = isPseudo;
 exports.isMediaQuery = isMediaQuery;
 exports.seperateStyles = seperateStyles;
 
-var _CSSPropertyOperations = require('react/lib/CSSPropertyOperations');
+var _CSSPropertyOperations = require('./CSSPropertyOperations');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -88,23 +88,23 @@ function isEmpty(obj) {
 }
 
 function isPseudo(_ref) {
-  var style = _ref.style;
-  var rule = _ref.rule;
+  var style = _ref.style,
+      rule = _ref.rule;
 
   return rule.charAt(0) === ':' && (typeof style === 'undefined' ? 'undefined' : (0, _typeof3.default)(style)) === 'object';
 }
 
 function isMediaQuery(_ref2) {
-  var style = _ref2.style;
-  var rule = _ref2.rule;
+  var style = _ref2.style,
+      rule = _ref2.rule;
 
   return rule.charAt(0) === '@' && (typeof style === 'undefined' ? 'undefined' : (0, _typeof3.default)(style)) === 'object';
 }
 
 function handle(type, acc, _ref3) {
-  var style = _ref3.style;
-  var rule = _ref3.rule;
-  var pseudos = arguments.length <= 3 || arguments[3] === undefined ? [] : arguments[3];
+  var style = _ref3.style,
+      rule = _ref3.rule;
+  var pseudos = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : [];
 
   var hash = createClassName(sortObject(style));
   var rules = pseudos.length ? [[].concat(rule, style, pseudos)] : rule;
@@ -126,10 +126,9 @@ function seperateStyles(styles) {
     }
 
     if (isMediaQuery(content)) {
-      var _seperateStyles = seperateStyles(content.style);
-
-      var style = _seperateStyles.style;
-      var pseudos = _seperateStyles.pseudos;
+      var _seperateStyles = seperateStyles(content.style),
+          style = _seperateStyles.style,
+          pseudos = _seperateStyles.pseudos;
 
       return handle('mediaQueries', acc, { rule: rule, style: style }, pseudos);
     }

--- a/lib/utils/CSSProperty.js
+++ b/lib/utils/CSSProperty.js
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule CSSProperty
+ */
+
+/**
+ * CSS properties which accept numbers but are not in units of "px".
+ */
+
+export const isUnitlessNumber = {
+  animationIterationCount: true,
+  borderImageOutset: true,
+  borderImageSlice: true,
+  borderImageWidth: true,
+  boxFlex: true,
+  boxFlexGroup: true,
+  boxOrdinalGroup: true,
+  columnCount: true,
+  flex: true,
+  flexGrow: true,
+  flexPositive: true,
+  flexShrink: true,
+  flexNegative: true,
+  flexOrder: true,
+  gridRow: true,
+  gridColumn: true,
+  fontWeight: true,
+  lineClamp: true,
+  lineHeight: true,
+  opacity: true,
+  order: true,
+  orphans: true,
+  tabSize: true,
+  widows: true,
+  zIndex: true,
+  zoom: true,
+
+  // SVG-related properties
+  fillOpacity: true,
+  floodOpacity: true,
+  stopOpacity: true,
+  strokeDasharray: true,
+  strokeDashoffset: true,
+  strokeMiterlimit: true,
+  strokeOpacity: true,
+  strokeWidth: true
+};
+
+/**
+ * @param {string} prefix vendor-specific prefix, eg: Webkit
+ * @param {string} key style name, eg: transitionDuration
+ * @return {string} style name prefixed with `prefix`, properly camelCased, eg:
+ * WebkitTransitionDuration
+ */
+function prefixKey(prefix, key) {
+  return prefix + key.charAt(0).toUpperCase() + key.substring(1);
+}
+
+/**
+ * Support style names that may come passed in prefixed by adding permutations
+ * of vendor prefixes.
+ */
+const prefixes = ['Webkit', 'ms', 'Moz', 'O'];
+
+// Using Object.keys here, or else the vanilla for-in loop makes IE8 go into an
+// infinite loop, because it iterates over the newly added props too.
+Object.keys(isUnitlessNumber).forEach(function (prop) {
+  prefixes.forEach(function (prefix) {
+    isUnitlessNumber[prefixKey(prefix, prop)] = isUnitlessNumber[prop];
+  });
+});
+
+/**
+ * Most style properties can be unset by doing .style[prop] = '' but IE8
+ * doesn't like doing that with shorthand properties so for the properties that
+ * IE8 breaks on, which are listed here, we instead unset each of the
+ * individual properties. See http://bugs.jquery.com/ticket/12385.
+ * The 4-value 'clock' properties like margin, padding, border-width seem to
+ * behave without any problems. Curiously, list-style works too without any
+ * special prodding.
+ */
+export const shorthandPropertyExpansions = {
+  background: {
+    backgroundAttachment: true,
+    backgroundColor: true,
+    backgroundImage: true,
+    backgroundPositionX: true,
+    backgroundPositionY: true,
+    backgroundRepeat: true
+  },
+  backgroundPosition: {
+    backgroundPositionX: true,
+    backgroundPositionY: true
+  },
+  border: {
+    borderWidth: true,
+    borderStyle: true,
+    borderColor: true
+  },
+  borderBottom: {
+    borderBottomWidth: true,
+    borderBottomStyle: true,
+    borderBottomColor: true
+  },
+  borderLeft: {
+    borderLeftWidth: true,
+    borderLeftStyle: true,
+    borderLeftColor: true
+  },
+  borderRight: {
+    borderRightWidth: true,
+    borderRightStyle: true,
+    borderRightColor: true
+  },
+  borderTop: {
+    borderTopWidth: true,
+    borderTopStyle: true,
+    borderTopColor: true
+  },
+  font: {
+    fontStyle: true,
+    fontVariant: true,
+    fontWeight: true,
+    fontSize: true,
+    lineHeight: true,
+    fontFamily: true
+  },
+  outline: {
+    outlineWidth: true,
+    outlineStyle: true,
+    outlineColor: true
+  }
+};

--- a/lib/utils/CSSPropertyOperations.js
+++ b/lib/utils/CSSPropertyOperations.js
@@ -1,0 +1,201 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule CSSPropertyOperations
+ */
+
+import { shorthandPropertyExpansions } from './CSSProperty';
+import dangerousStyleValue from './dangerousStyleValue';
+
+import {
+  ExecutionEnvironment,
+  camelizeStyleName,
+  hyphenateStyleName,
+  memoizeStringOnly,
+  warning
+} from './fbjs';
+
+// var ExecutionEnvironment = require('fbjs/lib/ExecutionEnvironment');
+// var camelizeStyleName = require('fbjs/lib/camelizeStyleName');
+// var hyphenateStyleName = require('fbjs/lib/hyphenateStyleName');
+// var memoizeStringOnly = require('fbjs/lib/memoizeStringOnly');
+// var warning = require('fbjs/lib/warning');
+
+var processStyleName = memoizeStringOnly(function (styleName) {
+  return hyphenateStyleName(styleName);
+});
+
+var hasShorthandPropertyBug = false;
+var styleFloatAccessor = 'cssFloat';
+if (ExecutionEnvironment.canUseDOM) {
+  var tempStyle = document.createElement('div').style;
+  try {
+    // IE8 throws "Invalid argument." if resetting shorthand style properties.
+    tempStyle.font = '';
+  } catch (e) {
+    hasShorthandPropertyBug = true;
+  }
+  // IE8 only supports accessing cssFloat (standard) as styleFloat
+  if (document.documentElement.style.cssFloat === undefined) {
+    styleFloatAccessor = 'styleFloat';
+  }
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  // 'msTransform' is correct, but the other prefixes should be capitalized
+  var badVendoredStyleNamePattern = /^(?:webkit|moz|o)[A-Z]/;
+
+  // style values shouldn't contain a semicolon
+  var badStyleValueWithSemicolonPattern = /;\s*$/;
+
+  var warnedStyleNames = {};
+  var warnedStyleValues = {};
+  var warnedForNaNValue = false;
+
+  var warnHyphenatedStyleName = function (name, owner) {
+    if (warnedStyleNames.hasOwnProperty(name) && warnedStyleNames[name]) {
+      return;
+    }
+
+    warnedStyleNames[name] = true;
+    warning(false, 'Unsupported style property %s. Did you mean %s?%s', name, camelizeStyleName(name), checkRenderMessage(owner));
+  };
+
+  var warnBadVendoredStyleName = function (name, owner) {
+    if (warnedStyleNames.hasOwnProperty(name) && warnedStyleNames[name]) {
+      return;
+    }
+
+    warnedStyleNames[name] = true;
+    warning(false, 'Unsupported vendor-prefixed style property %s. Did you mean %s?%s', name, name.charAt(0).toUpperCase() + name.slice(1), checkRenderMessage(owner));
+  };
+
+  var warnStyleValueWithSemicolon = function (name, value, owner) {
+    if (warnedStyleValues.hasOwnProperty(value) && warnedStyleValues[value]) {
+      return;
+    }
+
+    warnedStyleValues[value] = true;
+    warning(false, 'Style property values shouldn\'t contain a semicolon.%s ' + 'Try "%s: %s" instead.', checkRenderMessage(owner), name, value.replace(badStyleValueWithSemicolonPattern, ''));
+  };
+
+  var warnStyleValueIsNaN = function (name, value, owner) {
+    if (warnedForNaNValue) {
+      return;
+    }
+
+    warnedForNaNValue = true;
+    warning(false, '`NaN` is an invalid value for the `%s` css style property.%s', name, checkRenderMessage(owner));
+  };
+
+  var checkRenderMessage = function (owner) {
+    if (owner) {
+      var name = owner.getName();
+      if (name) {
+        return ' Check the render method of `' + name + '`.';
+      }
+    }
+    return '';
+  };
+
+  /**
+   * @param {string} name
+   * @param {*} value
+   * @param {ReactDOMComponent} component
+   */
+  var warnValidStyle = function (name, value, component) {
+    var owner;
+    if (component) {
+      owner = component._currentElement._owner;
+    }
+    if (name.indexOf('-') > -1) {
+      warnHyphenatedStyleName(name, owner);
+    } else if (badVendoredStyleNamePattern.test(name)) {
+      warnBadVendoredStyleName(name, owner);
+    } else if (badStyleValueWithSemicolonPattern.test(value)) {
+      warnStyleValueWithSemicolon(name, value, owner);
+    }
+
+    if (typeof value === 'number' && isNaN(value)) {
+      warnStyleValueIsNaN(name, value, owner);
+    }
+  };
+}
+
+/**
+ * Operations for dealing with CSS properties.
+ */
+
+/**
+ * Serializes a mapping of style properties for use as inline styles:
+ *
+ *   > createMarkupForStyles({width: '200px', height: 0})
+ *   "width:200px;height:0;"
+ *
+ * Undefined values are ignored so that declarative programming is easier.
+ * The result should be HTML-escaped before insertion into the DOM.
+ *
+ * @param {object} styles
+ * @param {ReactDOMComponent} component
+ * @return {?string}
+ */
+export function createMarkupForStyles (styles, component) {
+  var serialized = '';
+  for (var styleName in styles) {
+    if (!styles.hasOwnProperty(styleName)) {
+      continue;
+    }
+    var styleValue = styles[styleName];
+    if (process.env.NODE_ENV !== 'production') {
+      warnValidStyle(styleName, styleValue, component);
+    }
+    if (styleValue != null) {
+      serialized += processStyleName(styleName) + ':';
+      serialized += dangerousStyleValue(styleName, styleValue, component) + ';';
+    }
+  }
+  return serialized || null;
+}
+
+/**
+ * Sets the value for multiple styles on a node.  If a value is specified as
+ * '' (empty string), the corresponding style property will be unset.
+ *
+ * @param {DOMElement} node
+ * @param {object} styles
+ * @param {ReactDOMComponent} component
+ */
+export function setValueForStyles (node, styles, component) {
+  var style = node.style;
+  for (var styleName in styles) {
+    if (!styles.hasOwnProperty(styleName)) {
+      continue;
+    }
+    if (process.env.NODE_ENV !== 'production') {
+      warnValidStyle(styleName, styles[styleName], component);
+    }
+    var styleValue = dangerousStyleValue(styleName, styles[styleName], component);
+    if (styleName === 'float' || styleName === 'cssFloat') {
+      styleName = styleFloatAccessor;
+    }
+    if (styleValue) {
+      style[styleName] = styleValue;
+    } else {
+      var expansion = hasShorthandPropertyBug && shorthandPropertyExpansions[styleName];
+      if (expansion) {
+        // Shorthand property that IE8 won't like unsetting, so unset each
+        // component to placate it
+        for (var individualStyleName in expansion) {
+          style[individualStyleName] = '';
+        }
+      } else {
+        style[styleName] = '';
+      }
+    }
+  }
+}

--- a/lib/utils/dangerousStyleValue.js
+++ b/lib/utils/dangerousStyleValue.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule dangerousStyleValue
+ */
+
+import { isUnitlessNumber } from './CSSProperty';
+import { warning } from './fbjs';
+
+const styleWarnings = {};
+
+/**
+ * Convert a value into the proper css writable value. The style name `name`
+ * should be logical (no hyphens), as specified
+ * in `CSSProperty.isUnitlessNumber`.
+ *
+ * @param {string} name CSS property name such as `topMargin`.
+ * @param {*} value CSS property value such as `10px`.
+ * @param {ReactDOMComponent} component
+ * @return {string} Normalized style value with dimensions applied.
+ */
+export default function dangerousStyleValue(name, value, component) {
+  // Note that we've removed escapeTextForBrowser() calls here since the
+  // whole string will be escaped when the attribute is injected into
+  // the markup. If you provide unsafe user data here they can inject
+  // arbitrary CSS which may be problematic (I couldn't repro this):
+  // https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet
+  // http://www.thespanner.co.uk/2007/11/26/ultimate-xss-css-injection/
+  // This is not an XSS hole but instead a potential CSS injection issue
+  // which has lead to a greater discussion about how we're going to
+  // trust URLs moving forward. See #2115901
+
+  const isEmpty = value == null || typeof value === 'boolean' || value === '';
+  if (isEmpty) {
+    return '';
+  }
+
+  const isNonNumeric = isNaN(value);
+  if (isNonNumeric || value === 0 || isUnitlessNumber.hasOwnProperty(name) && isUnitlessNumber[name]) {
+    return '' + value; // cast to string
+  }
+
+  if (typeof value === 'string') {
+    if (process.env.NODE_ENV !== 'production') {
+      if (component) {
+        var owner = component._currentElement._owner;
+        var ownerName = owner ? owner.getName() : null;
+        if (ownerName && !styleWarnings[ownerName]) {
+          styleWarnings[ownerName] = {};
+        }
+        var warned = false;
+        if (ownerName) {
+          var warnings = styleWarnings[ownerName];
+          warned = warnings[name];
+          if (!warned) {
+            warnings[name] = true;
+          }
+        }
+        if (!warned) {
+          warning(false, 'a `%s` tag (owner: `%s`) was passed a numeric string value ' + 'for CSS property `%s` (value: `%s`) which will be treated ' + 'as a unitless number in a future version of React.', component._currentElement.type, ownerName || 'unknown', name, value);
+        }
+      }
+    }
+    value = value.trim();
+  }
+  return value + 'px';
+}

--- a/lib/utils/fbjs.js
+++ b/lib/utils/fbjs.js
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+ // ExecutionEnvironment.js
+
+ const canUseDOM = !!(
+   typeof window !== 'undefined' &&
+   window.document &&
+   window.document.createElement
+ );
+
+ /**
+  * Simple, lightweight module assisting with the detection and context of
+  * Worker. Helps avoid circular dependencies and allows code to reason about
+  * whether or not they are in a Worker, even if they never include the main
+  * `ReactWorker` dependency.
+  */
+ export const ExecutionEnvironment = {
+
+   canUseDOM: canUseDOM,
+
+   canUseWorkers: typeof Worker !== 'undefined',
+
+   canUseEventListeners:
+     canUseDOM && !!(window.addEventListener || window.attachEvent),
+
+   canUseViewport: canUseDOM && !!window.screen,
+
+   isInWorker: !canUseDOM // For now, this is true - might change in the future.
+
+ };
+
+
+ // ---------------------
+
+// hypenate.js
+
+const _uppercasePattern = /([A-Z])/g;
+
+/**
+ * Hyphenates a camelcased string, for example:
+ *
+ *   > hyphenate('backgroundColor')
+ *   < "background-color"
+ *
+ * For CSS style names, use `hyphenateStyleName` instead which works properly
+ * with all vendor prefixes, including `ms`.
+ *
+ * @param {string} string
+ * @return {string}
+ */
+function hyphenate(string) {
+  return string.replace(_uppercasePattern, '-$1').toLowerCase();
+}
+
+
+// ---------------------
+
+// hyphenateStyleName.js
+
+const msPattern = /^ms-/;
+
+/**
+ * Hyphenates a camelcased CSS property name, for example:
+ *
+ *   > hyphenateStyleName('backgroundColor')
+ *   < "background-color"
+ *   > hyphenateStyleName('MozTransition')
+ *   < "-moz-transition"
+ *   > hyphenateStyleName('msTransition')
+ *   < "-ms-transition"
+ *
+ * As Modernizr suggests (http://modernizr.com/docs/#prefixed), an `ms` prefix
+ * is converted to `-ms-`.
+ *
+ * @param {string} string
+ * @return {string}
+ */
+export function hyphenateStyleName(string) {
+  return hyphenate(string).replace(msPattern, '-ms-');
+}
+
+
+// ---------------------
+
+// camelize.js
+
+const _hyphenPattern = /-(.)/g;
+
+/**
+ * Camelcases a hyphenated string, for example:
+ *
+ *   > camelize('background-color')
+ *   < "backgroundColor"
+ *
+ * @param {string} string
+ * @return {string}
+ */
+function camelize(string) {
+  return string.replace(_hyphenPattern, function(_, character) {
+    return character.toUpperCase();
+  });
+}
+
+// ---------------------
+
+// camelizeStyleName.js
+
+const dashMsPattern = /^-ms-/; // renamed from msPattern to avoid name conflict
+
+/**
+ * Camelcases a hyphenated CSS property name, for example:
+ *
+ *   > camelizeStyleName('background-color')
+ *   < "backgroundColor"
+ *   > camelizeStyleName('-moz-transition')
+ *   < "MozTransition"
+ *   > camelizeStyleName('-ms-transition')
+ *   < "msTransition"
+ *
+ * As Andi Smith suggests
+ * (http://www.andismith.com/blog/2012/02/modernizr-prefixed/), an `-ms` prefix
+ * is converted to lowercase `ms`.
+ *
+ * @param {string} string
+ * @return {string}
+ */
+export function camelizeStyleName(string) {
+  return camelize(string.replace(dashMsPattern, 'ms-'));
+}
+
+
+// ---------------------
+
+// memoizeStringOnly.js
+
+/**
+ * Memoizes the return value of a function that accepts one string argument.
+ */
+export function memoizeStringOnly(callback) {
+  const cache = {};
+  return function(string) {
+    if (!cache.hasOwnProperty(string)) {
+      cache[string] = callback.call(this, string);
+    }
+    return cache[string];
+  };
+}
+
+
+// ---------------------
+
+// warning.js
+
+export const warning = function(){};
+
+// if (__DEV__) {
+//   function printWarning(format, ...args) {
+//     var argIndex = 0;
+//     var message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
+//     if (typeof console !== 'undefined') {
+//       console.error(message);
+//     }
+//     try {
+//       // --- Welcome to debugging React ---
+//       // This error was thrown as a convenience so that you can use this stack
+//       // to find the callsite that caused this warning to fire.
+//       throw new Error(message);
+//     } catch (x) {}
+//   }
+//
+//   warning = function(condition, format, ...args) {
+//     if (format === undefined) {
+//       throw new Error(
+//         '`warning(condition, format, ...args)` requires a warning ' +
+//         'message argument'
+//       );
+//     }
+//     if (!condition) {
+//       printWarning(format, ...args);
+//     }
+//   };
+// }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,4 +1,4 @@
-import { createMarkupForStyles } from 'react/lib/CSSPropertyOperations';
+import { createMarkupForStyles } from './CSSPropertyOperations';
 
 export function sortObject(obj) {
   return Object.keys( obj )

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "babel-runtime": "^6.6.1",
-    "react": ">=0.11.0"
+    "babel-runtime": "^6.6.1"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",


### PR DESCRIPTION
@SpainTrain @dano-giftbit @esturcke @webpapaya I've finally had the time to look at the issue with having React as a dependency.

The solution I decided to use, is to fork `createMarkupForStyles` and it's internal dependencies from `react` and `fbjs`.

This will close #12 and #37 - and goes instead of #38 and #31 

I'm adding tests to this PR right now, but would like feedback